### PR TITLE
fix crash

### DIFF
--- a/src/Worktree.ts
+++ b/src/Worktree.ts
@@ -206,7 +206,7 @@ export class WorktreeProvider implements vscode.TreeDataProvider<Worktree> {
             const line = element.trim().split(/\s+/);
             // console.log(Object.values(line))
 
-            if (Object.values(line).length === 1) { return; }
+            if (Object.values(line).length === 1 || line.at(1) === '(bare)') { return; }
 
             const openCommand: vscode.Command = {
                 title: "open",


### PR DESCRIPTION
on my laptop (arch linux 6.2.2, vscode 1.76, git 2.39.2) i was getting that error:
![Screenshot from 2023-03-09 19-58-18](https://user-images.githubusercontent.com/96233899/224115809-6f0c1d18-1fe1-4808-a72a-a6fc0aa292bb.png)

this was caused by the fact that git, when executing `git worktree list`, returned the parent-bare repository in addition to the branches, and the following object was passed to the function:
![Screenshot from 2023-03-09 19-59-10](https://user-images.githubusercontent.com/96233899/224116853-3e31bf58-d3ac-4dfe-815b-8d6f290c5ddf.png)
