### PR TITLE
Do not show bare copy of submodules in worktree list

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Worktrees are a core feature of git. You can use this feature when you want to h
 ---
 ## Release Notes
 
+### 1.0.3
+
+Do not show bare copy of submodules in worktree list - [@SR_team](https://github.com/sr-tream)
+
 ### 1.0.2
 
 fixes a crash when workspace is open to a bare git repo - [@kryyova](https://github.com/kryyova)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "git-worktree-menu",
   "displayName": "Git Worktree Menu",
   "description": "Displays a menu for viewing, switching, creating, and removing git worktrees",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "publisher": "CodeInKlingon",
   "engines": {
     "vscode": "^1.70.0"

--- a/src/Worktree.ts
+++ b/src/Worktree.ts
@@ -1,4 +1,6 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+import { join as join_path } from 'path';
 
 import { simpleGit } from 'simple-git';
 import path = require('node:path');
@@ -207,6 +209,8 @@ export class WorktreeProvider implements vscode.TreeDataProvider<Worktree> {
             // console.log(Object.values(line))
 
             if (Object.values(line).length === 1 || line.at(1) === '(bare)') { return; }
+
+            if (!fs.existsSync(join_path(line[0], ".git"))) { return; }
 
             const openCommand: vscode.Command = {
                 title: "open",


### PR DESCRIPTION
The `git worktree list` may show bare repo, but instead of `(bare)` print commit of this repo. We can filter it by check is existing file `.git` in worktree.