### PR TITLE
Starting select parent folder from workspace directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Worktrees are a core feature of git. You can use this feature when you want to h
 ---
 ## Release Notes
 
+### 1.0.4
+
+Start select parent folder from workspace directory and keep last worktree directory path (runtime only) - [@SR_team](https://github.com/sr-tream)
+
 ### 1.0.3
 
 Do not show bare copy of submodules in worktree list - [@SR_team](https://github.com/sr-tream)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "git-worktree-menu",
   "displayName": "Git Worktree Menu",
   "description": "Displays a menu for viewing, switching, creating, and removing git worktrees",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "publisher": "CodeInKlingon",
   "engines": {
     "vscode": "^1.70.0"

--- a/src/Worktree.ts
+++ b/src/Worktree.ts
@@ -8,6 +8,7 @@ import path = require('node:path');
 export class WorktreeProvider implements vscode.TreeDataProvider<Worktree> {
 
     _rootPath: string | undefined = undefined;
+    _lastWorktreePath: vscode.Uri | undefined = undefined;
 
     public worktrees: Worktree[];
     private _onDidChangeTreeData: vscode.EventEmitter<Worktree | undefined | void> = new vscode.EventEmitter<Worktree | undefined | void>();
@@ -77,14 +78,20 @@ export class WorktreeProvider implements vscode.TreeDataProvider<Worktree> {
 
         if (pick?.id === 1) { return; }
 
+        let workspaceUri = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri : undefined;
+        let defaultUri = this._lastWorktreePath || workspaceUri;
+
         //select path
         let fileUri = await vscode.window.showOpenDialog({
+            defaultUri: defaultUri,
             canSelectMany: false,
             openLabel: 'Select parent path for new worktree',
             canSelectFiles: false,
             canSelectFolders: true
         });
         if (!fileUri) { return; }
+
+        this._lastWorktreePath = fileUri[0];
 
         vscode.window.showInformationMessage('Selected parent folder: ' + fileUri[0].fsPath);
 
@@ -172,7 +179,6 @@ export class WorktreeProvider implements vscode.TreeDataProvider<Worktree> {
         vscode.window.showInformationMessage(e);
 
         this.refresh();
-
     }
 
     getTreeItem(element: Worktree): vscode.TreeItem {


### PR DESCRIPTION
Now when user adding new worktree, the parent folder selector starts selecting from current workspace directory, instead of user home. It also keeps the last parent workspace folder in runtime.

I tried to save last selected parent folder in workspace settings, but it requires declaring settings in `package.json`, what cannot be hidden from user settings. So for now this selection keeps only for runtime, may be later it can be stored in own dot-file in workspace or `.vscode` folder.

Known issues:
- KDE file choser has ignoring option `defaultUri`.
    Workarounds:
     - use VSCode simple dialog for file choser.
     - use GTK file choser (set env `GTK_USE_PORTAL=0`)