### PR TITLE
Configure list of paths to copy in new worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Worktrees are a core feature of git. You can use this feature when you want to h
 
 ## Release Notes
 
+### 1.0.6
+
+Configure list of paths to copy in new worktree - [@SR_team](https://github.com/sr-tream)
+
 ### 1.0.5
 
 Fix "separate" typo

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "git-worktree-menu",
   "displayName": "Git Worktree Menu",
   "description": "Displays a menu for viewing, switching, creating, and removing git worktrees",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "publisher": "CodeInKlingon",
   "engines": {
     "vscode": "^1.70.0"
@@ -94,6 +94,22 @@
           "when": "view == worktreeDependencies && viewItem == other-worktree"
         }
       ]
+    },
+    "configuration": {
+      "type": "object",
+      "title": "Git Worktree Menu",
+      "properties": {
+        "git-worktree-menu.copyPaths": {
+          "type": "array",
+          "default": [
+            ".vscode"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "List of local paths to copy to worktree."
+        }
+      }
     }
   },
   "scripts": {

--- a/src/CopyPath.ts
+++ b/src/CopyPath.ts
@@ -1,0 +1,40 @@
+import * as fs from 'fs';
+import { join as join_path, dirname } from 'path';
+
+function copyDir(src: string, dst: string) {
+    if (!fs.existsSync(dst)) {
+        fs.mkdirSync(dst, { recursive: true });
+    }
+
+    const files = fs.readdirSync(src);
+
+    for (let i = 0; i < files.length; i++) {
+        const filename = join_path(src, files[i]);
+        const stat = fs.lstatSync(filename);
+
+        if (stat.isDirectory()) {
+            copyDir(filename, join_path(dst, files[i]));
+        } else {
+            fs.copyFileSync(filename, join_path(dst, files[i]));
+        }
+    }
+}
+
+export function copyPath(src: string, dst: string) {
+    if (!fs.existsSync(src)) {
+        return;
+    }
+
+    const destDir = dirname(dst);
+    if (!fs.existsSync(destDir)) {
+        fs.mkdirSync(destDir, { recursive: true });
+    }
+
+    const stat = fs.lstatSync(src);
+
+    if (stat.isDirectory()) {
+        copyDir(src, dst);
+    } else {
+        fs.copyFileSync(src, dst);
+    }
+}

--- a/src/Worktree.ts
+++ b/src/Worktree.ts
@@ -5,6 +5,9 @@ import { join as join_path } from 'path';
 import { simpleGit } from 'simple-git';
 import path = require('node:path');
 
+import { Config } from './config';
+import { copyPath } from './CopyPath';
+
 export class WorktreeProvider implements vscode.TreeDataProvider<Worktree> {
 
     _rootPath: string | undefined = undefined;
@@ -177,6 +180,15 @@ export class WorktreeProvider implements vscode.TreeDataProvider<Worktree> {
 
         let e = await simpleGit(this.workspaceRoot).raw(...commands);
         vscode.window.showInformationMessage(e);
+
+        if (this.workspaceRoot) {
+            const copyPaths = Config.read().copyPaths;
+            for (const p of copyPaths) {
+                const src = join_path(this.workspaceRoot, p);
+                const dst = join_path(pathForBranch, p);
+                copyPath(src, dst);
+            }
+        }
 
         this.refresh();
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,17 @@
+import * as vscode from 'vscode';
+
+export namespace Config {
+    export const EXTENSION_NAME = 'git-worktree-menu';
+
+    export interface Global {
+        copyPaths: string[]
+    }
+    export const DEFAULT_GLOBAL: Global = {
+        copyPaths: ['.vscode']
+    }
+
+    export function read(): Global {
+        const config = vscode.workspace.getConfiguration();
+        return config.get<Global>(EXTENSION_NAME, DEFAULT_GLOBAL);
+    }
+}


### PR DESCRIPTION
In most cases, when I create a new worktree, I need to copy semi of my local files: VSCode settings, CMake user presets, some scripts - all what I don't want to commit to repo. This PR solve this - it's adding config for list of path what will be copied to new worktree.

By default, copies only `.vscode` folder