### PR TITLE
Add a new setting to save parent worktree directory for current workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Configure a list of paths (files or folders) that will be copied from the curren
 
 ## Release Notes
 
+### 1.0.8
+
+Keep parent folder for worktrees in settings - [@SR_team](https://github.com/sr-tream)
+
 ### 1.0.7
 
 Introduce extension logo and update readme

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Git Worktree Menu",
   "description": "Displays a menu for viewing, switching, creating, and removing git worktrees",
   "icon": "images/Git_Worktree_Menu.png",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "publisher": "CodeInKlingon",
   "engines": {
     "vscode": "^1.70.0"
@@ -109,6 +109,16 @@
             "type": "string"
           },
           "description": "List of local paths to copy to worktree."
+        },
+        "git-worktree-menu.worktreeDir": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "title": "Path to create worktree's",
+          "description": "Default path to create worktrees in. If not set, this extension ask you for a path when you first use the command.",
+          "scope": "machine-overridable"
         }
       }
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,17 +1,77 @@
 import * as vscode from 'vscode';
+import { ConfigurationTarget } from 'vscode';
 
 export namespace Config {
     export const EXTENSION_NAME = 'git-worktree-menu';
 
+    export interface WorktreeDir {
+        workspaceFolder: string | null,
+        workspace: string | null,
+        global: string | null
+    }
+    export const DEFAULT_WORKTREE_DIR: WorktreeDir = {
+        workspaceFolder: null,
+        workspace: null,
+        global: null
+    }
+
     export interface Global {
-        copyPaths: string[]
+        copyPaths: string[],
+        worktreeDir: WorktreeDir
     }
     export const DEFAULT_GLOBAL: Global = {
-        copyPaths: ['.vscode']
+        copyPaths: ['.vscode'],
+        worktreeDir: DEFAULT_WORKTREE_DIR
+    }
+
+    interface Package {
+        copyPaths: string[],
+        worktreeDir: string | null
     }
 
     export function read(): Global {
         const config = vscode.workspace.getConfiguration();
-        return config.get<Global>(EXTENSION_NAME, DEFAULT_GLOBAL);
+        const global = config.inspect<Package>(EXTENSION_NAME);
+        if (global === undefined) {
+            return DEFAULT_GLOBAL;
+        }
+
+        let result: Global = {
+            copyPaths: [],
+            worktreeDir: DEFAULT_WORKTREE_DIR
+        };
+
+        if (global.workspaceFolderValue !== undefined) {
+            global.workspaceFolderValue.copyPaths?.forEach((path: string) => {
+                result.copyPaths.push(path);
+            });
+            if (global.workspaceFolderValue.worktreeDir !== undefined) {
+                result.worktreeDir.workspaceFolder = global.workspaceFolderValue.worktreeDir;
+            }
+        }
+
+        if (global.workspaceValue !== undefined) {
+            global.workspaceValue.copyPaths?.forEach((path: string) => {
+                if (result.copyPaths.indexOf(path) == -1) {
+                    result.copyPaths.push(path);
+                }
+            });
+            if (global.workspaceValue.worktreeDir !== undefined) {
+                result.worktreeDir.workspace = global.workspaceValue.worktreeDir;
+            }
+        }
+
+        if (global.globalValue !== undefined) {
+            if (result.copyPaths.length == 0) {
+                global.globalValue.copyPaths?.forEach((path: string) => {
+                    result.copyPaths.push(path);
+                });
+            }
+            if (global.globalValue.worktreeDir !== undefined) {
+                result.worktreeDir.global = global.globalValue.worktreeDir;
+            }
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
**Global Setting**

Used as a default path for prompting where to create the worktree.

**Workspace Setting**

Skips the prompt and creates the worktree in the specified directory by default.